### PR TITLE
Load project python files into pyodide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pyenv
 .pytest_cache
 __pycache__
 .mypy_cache
+.pyvenv

--- a/script/build.sh
+++ b/script/build.sh
@@ -6,6 +6,8 @@ echo "BUILD START $(date)"
 
 $this_dir/tsc_build.sh
 
+$this_dir/insert_managed_by_build_ts.sh
+
 cd $this_dir/../src/ts
 
 mkdir -p build/upload

--- a/script/compose_managed_by_build_ts_source_file
+++ b/script/compose_managed_by_build_ts_source_file
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import sys
+from typing import Dict
+
+
+class TsConstant:
+    name: str
+    value: Dict
+    comment: str
+
+    def __init__(
+            self,
+            name: str,
+            value: Dict,
+            comment: str
+    ) -> None:
+        self.name = name
+        self.value = value
+        self.comment = comment
+
+
+ts_constants = []
+
+python_relative_path_to_content = {}
+
+python_source_root = sys.argv[1]
+for root, dirs, files in os.walk(python_source_root, topdown=False):
+    relative_dir = root.replace(python_source_root + "/", "")
+    for name in files:
+        if name.endswith(".py") and not name.startswith("test_"):
+            relative_path = os.path.join(relative_dir, name)
+            path = os.path.join(root, name)
+            with open(path) as f:
+                python_relative_path_to_content[relative_path] = f.read()
+
+ts_constants.append(
+    TsConstant(
+        name="PROJECT_PYTHON_FILES",
+        value=python_relative_path_to_content,
+        comment="Map of path to content of all project python files, excepting test-related files."))
+
+
+def convert_ts_constant_to_ts_string(ts_constant: TsConstant) -> str:
+    result = "// %s\n" % ts_constant.comment
+    result += "export const %s: { [key: string]: string } = %s\n" % (
+    ts_constant.name, json.dumps(ts_constant.value, indent=4, sort_keys=True))
+    return result
+
+
+print("\n\n".join(map(convert_ts_constant_to_ts_string, ts_constants)))

--- a/script/insert_managed_by_build_ts.sh
+++ b/script/insert_managed_by_build_ts.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -ex
+
+this_dir=$(dirname $0)
+
+codegen_init_dir=$this_dir/../src/ts/build/codegen/init
+$this_dir/compose_managed_by_build_ts_source_file $this_dir/../src/py > /tmp/managed-by-build.ts.new
+
+should_compile=yes
+
+if [ -f $codegen_init_dir/managed-by-build.ts ]; then
+    set +e
+    diff $codegen_init_dir/managed-by-build.ts /tmp/managed-by-build.ts.new
+    if [ "0" = "$?" ]; then
+        echo "managed-by-build.ts matches, skip compile"
+        should_compile=no
+    fi
+    set -e
+fi
+
+mkdir -p $codegen_init_dir
+echo '{"extends": "../../../tsconfig-core.json"}' > $codegen_init_dir/tsconfig.json
+mv /tmp/managed-by-build.ts.new $codegen_init_dir/managed-by-build.ts
+
+if [ $should_compile = "yes" ]; then
+    time $this_dir/../src/ts/node_modules/.bin/tsc --incremental -p $codegen_init_dir/tsconfig.json
+    cp $codegen_init_dir/managed-by-build.* $this_dir/../src/ts/build/tsc/init/src/
+fi

--- a/src/py/basic/append.py
+++ b/src/py/basic/append.py
@@ -1,0 +1,2 @@
+def append(str: str, suffix: str) -> str:
+    return str + suffix

--- a/src/py/basic/test_append.py
+++ b/src/py/basic/test_append.py
@@ -1,0 +1,5 @@
+from append import append
+
+
+def test_append() -> None:
+    assert "hello world" == append("hello ", "world")

--- a/src/py/requirements.txt
+++ b/src/py/requirements.txt
@@ -1,2 +1,5 @@
+# note - pip modules are currently dev-only
+# assume that the "production" python environment is highly constrained
+
 pytest==5.4.2
 mypy==0.770

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -1,28 +1,9 @@
 <html>
 <head>
+  <script>
+    window.start = new Date().getTime()
+  </script>
   <script src=" https://pyodide-cdn2.iodide.io/v0.15.0/full/pyodide.js"></script>
   <script src="./bundle.js"></script>
 </head>
-<body>
-<script type="text/javascript">
-  const start = new Date().getTime()
-  languagePluginLoader.then(function () {
-    pyodide.runPython("print('hello world, from Python')");
-    console.log(new Date().getTime() - start)
-
-    pyodide.runPython(`
-                import ast
-                print(ast.parse("print('hello world, from Python AST')"))
-
-                import sys
-                print("Python version")
-                print (sys.version)
-                print("Version info.")
-                print (sys.version_info)
-                `);
-    console.log(new Date().getTime() - start)
-  });
-
-</script>
-</body>
 </html>

--- a/src/ts/init/src/init.ts
+++ b/src/ts/init/src/init.ts
@@ -1,5 +1,60 @@
 import {prepend} from "basic/prepend";
+import {PROJECT_PYTHON_FILES} from "init/managed-by-build"
+
+declare const languagePluginLoader: Promise<any>
+declare const pyodide: any
+
+const start = (<any>window).start
+console.log(new Date().getTime() - start)
 
 console.log(prepend("hello ", "world, from TypeScript"))
+console.log(PROJECT_PYTHON_FILES)
 
 
+document.addEventListener("DOMContentLoaded", function () {
+    languagePluginLoader.then(() => {
+
+        const pathsCreated: { [key: string]: boolean } = {}
+        pyodide._module.FS.mkdir("/py")
+
+        for (let relativePath in PROJECT_PYTHON_FILES) {
+            const relativeDirectory = relativePath.substring(0, relativePath.lastIndexOf("/"))
+
+            const parts = relativeDirectory.split("/")
+
+            let dir = "/py"
+            parts.forEach((part) => {
+                dir = dir + "/" + part
+                if (!pathsCreated[dir]) {
+                    pyodide._module.FS.mkdir(dir)
+                    pathsCreated[dir] = true
+                }
+            })
+
+            pyodide._module.FS.writeFile("/py/" + relativePath, PROJECT_PYTHON_FILES[relativePath])
+        }
+
+
+        pyodide.runPython("print('hello world, from Python')");
+
+        console.log(new Date().getTime() - start)
+
+        pyodide.runPython(`
+            import ast
+            print(ast.parse("print('hello world, from Python AST')"))
+
+            import sys
+            print("Python version")
+            print (sys.version)
+            print("Version info.")
+            print (sys.version_info)
+
+            # make use of a function that comes from python code loaded is from the surrounding project
+            sys.path.append("/py/basic")
+            from append import append
+            print(append("appended hello ", "world"))
+            `);
+
+        console.log(new Date().getTime() - start)
+    })
+})

--- a/src/ts/init/src/managed-by-build.ts
+++ b/src/ts/init/src/managed-by-build.ts
@@ -1,0 +1,5 @@
+// The build injects a json map here, which is a map of
+// containing python file, to content, of all "production" python code in the project
+
+export const PROJECT_PYTHON_FILES: { [key: string]: string } = {}
+

--- a/src/ts/package-lock.json
+++ b/src/ts/package-lock.json
@@ -279,6 +279,12 @@
         "@types/node": "*"
       }
     },
+    "@types/emscripten": {
+      "version": "1.39.4",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.39.4.tgz",
+      "integrity": "sha512-k3LLVMFrdNA9UCvMDPWMbFrGPNb+GcPyw29ktJTo1RCN7RmxFG5XzPZcPKRlnLuLT/FRm8wp4ohvDwNY7GlROQ==",
+      "dev": true
+    },
     "@types/estree": {
       "version": "0.0.44",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.44.tgz",

--- a/src/ts/package.json
+++ b/src/ts/package.json
@@ -21,6 +21,7 @@
     "@types/chai": "4.2.11",
     "mocha": "7.2.0",
     "@types/mocha": "7.0.2",
-    "tsconfig-paths": "3.9.0"
+    "tsconfig-paths": "3.9.0",
+    "@types/emscripten": "1.39.4"
   }
 }

--- a/src/ts/tsconfig-base.json
+++ b/src/ts/tsconfig-base.json
@@ -1,29 +1,6 @@
 {
+  "extends": "./tsconfig-core.json",
   "compilerOptions": {
-    "pretty": true,
-    "lib": [
-      "es2015.iterable",
-      "es2015.generator",
-      "es5",
-      "dom"
-    ],
-    "target": "es5",
-    "rootDir": ".",
-    "declaration": true,
-    "declarationMap": true,
-    "inlineSourceMap": true,
-    "composite": true,
-    "noEmitOnError": true,
-    "strictNullChecks": true,
-    "noImplicitAny": true,
-    "noImplicitThis": true,
-    "strictPropertyInitialization": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "skipLibCheck": true,
-    "alwaysStrict": true,
-    "preserveConstEnums": true,
-    "newLine": "lf",
     "outDir": "./build/tsc",
     "baseUrl": ".",
     "paths": {
@@ -31,7 +8,8 @@
         "./basic/src/*"
       ],
       "init/*": [
-        "./init/src/*"
+        "./init/src/*",
+        "./build/codegen/init/*"
       ]
     }
   },

--- a/src/ts/tsconfig-core.json
+++ b/src/ts/tsconfig-core.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "pretty": true,
+    "lib": [
+      "es2015.iterable",
+      "es2015.generator",
+      "es5",
+      "dom"
+    ],
+    "target": "es5",
+    "rootDir": ".",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSourceMap": true,
+    "composite": true,
+    "noEmitOnError": true,
+    "strictNullChecks": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictPropertyInitialization": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "skipLibCheck": true,
+    "alwaysStrict": true,
+    "preserveConstEnums": true,
+    "newLine": "lf"
+  }
+}


### PR DESCRIPTION
- The build codegen's a typescript file, managed-by-build.ts,
  which is generated from a python script.
- The generated ts file contains a mapping of all
  project python paths, to the corresponding code from
  each file.
- Using the emscripten file access api, load each of these
  files into pyodide at page load time
- Demonstrate end-to-end by calling a function from
  a project python file, from pyodide.

two production py files
system for generating, compiling, and bundling managed-by-build.ts
load all non-test py files into PROJECT_PYTHON_FILES typescript constant
demonstration of loading python project files into pyodide and calling a function