### PR TITLE
Locate interpreters etc as symlinks under ./bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ pyenv
 __pycache__
 .mypy_cache
 .pyvenv
+bin/

--- a/script/build.sh
+++ b/script/build.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -ex
 
 this_dir=$(dirname $0)
+PATH="/usr/bin:/bin:/usr/sbin:/sbin:$($this_dir/../bin/realpath $this_dir/../bin)"
 
 echo "BUILD START $(date)"
 

--- a/script/compose_managed_by_build_ts_source_file.py
+++ b/script/compose_managed_by_build_ts_source_file.py
@@ -1,10 +1,7 @@
-#!/usr/bin/env python3
-
 import json
 import os
 import sys
 from typing import Dict
-
 
 class TsConstant:
     name: str
@@ -46,7 +43,7 @@ ts_constants.append(
 def convert_ts_constant_to_ts_string(ts_constant: TsConstant) -> str:
     result = "// %s\n" % ts_constant.comment
     result += "export const %s: { [key: string]: string } = %s\n" % (
-    ts_constant.name, json.dumps(ts_constant.value, indent=4, sort_keys=True))
+        ts_constant.name, json.dumps(ts_constant.value, indent=4, sort_keys=True))
     return result
 
 

--- a/script/deploy.sh
+++ b/script/deploy.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -ex
 
 this_dir=$(dirname $0)
+PATH="/usr/bin:/bin:/usr/sbin:/sbin:$($this_dir/../bin/realpath $this_dir/../bin)"
 
 file $this_dir/../src/ts/build/upload/index.html
 file $this_dir/../src/ts/build/upload/bundle.js

--- a/script/gh-action-master.sh
+++ b/script/gh-action-master.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -ex
 
 this_dir=$(dirname $0)
+PATH="/usr/bin:/bin:/usr/sbin:/sbin"
 
 time $this_dir/init_ts.sh
 time $this_dir/init_py.sh

--- a/script/gh-action-off-master.sh
+++ b/script/gh-action-off-master.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -ex
 
 this_dir=$(dirname $0)
+PATH="/usr/bin:/bin:/usr/sbin:/sbin"
 
 time $this_dir/init_ts.sh
 time $this_dir/init_py.sh

--- a/script/init_ts.sh
+++ b/script/init_ts.sh
@@ -1,11 +1,17 @@
 #!/bin/bash -ex
 
 this_dir=$(dirname $0)
+PATH="/usr/bin:/bin:/usr/sbin:/sbin"
 
-if [ -n "$GITHUB_RUN_ID" -a -d "$this_dir/../src/ts/node_modules" ]; then
-    # we assume the proper node_modules dir has been restored from cache
-    exit 0
+bin_dir=$(dirname $0)/../bin
+
+test -d $bin_dir || mkdir $bin_dir
+ln -sf /usr/local/bin/node $bin_dir/node
+ln -sf /usr/local/bin/npm $bin_dir/npm
+
+# in the build, the cache is keyed on a hash of package-lock.json
+if [ ! -d "$this_dir/../src/ts/node_modules" -o $(uname) = "Darwin" ]; then
+    cd $this_dir/../src/ts
+    time ../../bin/npm install
 fi
 
-cd $this_dir/../src/ts
-time npm install

--- a/script/insert_managed_by_build_ts.sh
+++ b/script/insert_managed_by_build_ts.sh
@@ -1,9 +1,10 @@
 #!/bin/bash -ex
 
 this_dir=$(dirname $0)
+PATH="/usr/bin:/bin:/usr/sbin:/sbin:$($this_dir/../bin/realpath $this_dir/../bin)"
 
 codegen_init_dir=$this_dir/../src/ts/build/codegen/init
-$this_dir/compose_managed_by_build_ts_source_file $this_dir/../src/py > /tmp/managed-by-build.ts.new
+python3 $this_dir/compose_managed_by_build_ts_source_file.py $this_dir/../src/py > /tmp/managed-by-build.ts.new
 
 should_compile=yes
 

--- a/script/launch_local_server.sh
+++ b/script/launch_local_server.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -ex
 
 this_dir=$(dirname $0)
+PATH="/usr/bin:/bin:/usr/sbin:/sbin:$($this_dir/../bin/realpath $this_dir/../bin)"
 
 test -d $this_dir/../src/ts/build/upload
 test -f $this_dir/../src/ts/node_modules/.bin/live-server

--- a/script/test_py.sh
+++ b/script/test_py.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -ex
 
 this_dir=$(dirname $0)
+PATH="/usr/bin:/bin:/usr/sbin:/sbin:$($this_dir/../bin/realpath $this_dir/../bin)"
 
 cd $this_dir/../src/py
 

--- a/script/test_ts.sh
+++ b/script/test_ts.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -ex
 
 this_dir=$(dirname $0)
+PATH="/usr/bin:/bin:/usr/sbin:/sbin:$($this_dir/../bin/realpath $this_dir/../bin)"
 
 cd $this_dir/..
 

--- a/script/tsc_build.sh
+++ b/script/tsc_build.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -ex
 
 this_dir=$(dirname $0)
+PATH="/usr/bin:/bin:/usr/sbin:/sbin:$($this_dir/../bin/realpath $this_dir/../bin)"
 
 cd $this_dir/../src/ts
 

--- a/script/typecheck_py.sh
+++ b/script/typecheck_py.sh
@@ -1,7 +1,8 @@
 #!/bin/bash -ex
 
 this_dir=$(dirname $0)
+PATH="/usr/bin:/bin:/usr/sbin:/sbin:$($this_dir/../bin/realpath $this_dir/../bin)"
 
 cd $this_dir/../src/py
 
-find . -name '*.py' | xargs /home/runner/.local/bin/mypy --strict
+find . -name '*.py' | xargs mypy --strict


### PR DESCRIPTION
install python under ~/.program-world
init nodejs
init / symlinks in bin dir
symlinking approach, explicit+constrained PATH